### PR TITLE
Fix ping method to use `ping/whoami` endpoint

### DIFF
--- a/monzo.go
+++ b/monzo.go
@@ -36,11 +36,8 @@ func NewClient(token string) *Client {
 
 // Ping attempts to connect to the Monzo API using the given
 // client.
-//
-// No "ping" endpoint currently exists at Monzo, so for now
-// this simply queries the /accounts endpoint.
 func (c *Client) Ping() error {
-	req, err := c.NewRequest(http.MethodGet, "accounts", nil)
+	req, err := c.NewRequest(http.MethodGet, "ping/whoami", nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Inspecting requests made on `web.monzo.com`, it turns out a ping endpoint does exist after all. Updated to use this endpoint.